### PR TITLE
Added initial GL context and window clearing function

### DIFF
--- a/examples/premake/premake5.lua
+++ b/examples/premake/premake5.lua
@@ -51,4 +51,8 @@ project "hello-world"
 project "input-polling"
     set_example_project_defaults()
     files { "../input-polling/**.*", }
+
+project "rendering"
+    set_example_project_defaults()
+    files { "../rendering/**.*", }
     

--- a/examples/rendering/rendering.cpp
+++ b/examples/rendering/rendering.cpp
@@ -1,0 +1,54 @@
+/// @file rendering.cpp
+/// @brief presents some rendering examples
+
+#include <bEngineApp.h>       // for access to the bEngineApp class and creation function
+#include <bEngineUtilities.h> // for printing information to the console to prove we're actually using the desired functions
+#include <bEngineWindow.h> // for access to the bEngineWindow class and creation function
+
+#include <format>
+
+namespace
+{
+    unsigned int g_mainWindowHandle{UINT_MAX};
+}
+
+// the initialization function just creates the main window and stores the handle in the global variable
+const bool initialize(bEngine::bEngineApp *const app)
+{
+    g_mainWindowHandle = app->add_window(bEngine::bEngineWindow::create_window(1280, 720));
+
+    // assume all other initialization went well; this is just the barebones example after all; return true so the
+    // app continues to load/initialize
+    //
+    // returning false would result in the program crashing
+
+    return true;
+}
+
+/// @brief the render function for the application which occurs as often as possible
+///
+/// this allows the user to actually issue a render command  only as often as desired (i.e. one can keep track of the
+/// time in an accumulator and only issue an actual render command when the accumulator is greater than a certain
+/// value)
+/// @param deltaTime the amount of time (in seconds) since the last run of the render function
+void render(const double deltaTime)
+{
+    // just clear the window-- that's all for now!
+    const auto mainWindow = bEngine::get_app().get_window(g_mainWindowHandle);
+
+    // clear with a "red" color
+    mainWindow->clear(1.0f, 0.0f, 0.0f);
+
+    // we also need to be sure to present the results of the rendering with the window...
+    mainWindow->present();
+}
+
+namespace bEngine
+{
+    bEngineApp app{bEngineApp::create_app("Hello World", initialize, nullptr, render, nullptr)};
+
+    bEngineApp &get_app()
+    {
+        return app;
+    }
+} // namespace bEngine

--- a/include/bEngineWindow.h
+++ b/include/bEngineWindow.h
@@ -33,9 +33,9 @@ namespace bEngine
         /// @param title the desired title of the window, or the default window title if not provided
         /// @return a unique pointer to the new window which was created with the provided arguments
         static std::unique_ptr<bEngineWindow> create_window(
-            const int        width,
-            const int        height,
-            std::string    &&title       = std::string{s_defaultWindowName});
+            const int     width,
+            const int     height,
+            std::string &&title = std::string{s_defaultWindowName});
 
         // private members/data
       private:
@@ -56,6 +56,9 @@ namespace bEngine
 
         /// @the platform-specific window implementation; defined in the bEngineWindow.cpp file and must be implemented
         /// per-platform
+        ///
+        /// each platform's PIMPL will also manage a GL context such that window drawing/rendering commands can use the
+        /// correct function pointers; no need to actually expose the GL context struct however!
         struct PlatformWindowImpl;
 
         /// @brief store a unique pointer to the PlatformWindowImpl as per the PIMPL idiom
@@ -90,11 +93,7 @@ namespace bEngine
         /// @param width the desired width of the window
         /// @param height the desired height of the window
         /// @param title the desired title for the window
-        bEngineWindow(
-            WindowToken      token,
-            const int        width,
-            const int        height,
-            std::string    &&title);
+        bEngineWindow(WindowToken token, const int width, const int height, std::string &&title);
 
         // public methods/functions so the window can actually be used by the application
       public:

--- a/include/bEngineWindow.h
+++ b/include/bEngineWindow.h
@@ -97,6 +97,13 @@ namespace bEngine
 
         // public methods/functions so the window can actually be used by the application
       public:
+        /// @brief uses the desired color to clear the window
+        /// @param r the red component to use for the color to clear the window with, defaults to 0.0
+        /// @param r the green component to use for the color to clear the window with, defaults to 0.0
+        /// @param r the blue component to use for the color to clear the window with, defaults to 0.0
+        /// @param r the alpha component to use for the color to clear the window with, defaults to 1.0
+        void clear(const float r = 0.0f, const float g = 0.0f, const float b = 0.0f, const float a = 1.0f) const;
+
         /// @brief gets the input state associated with the window
         /// @return the input state associated with the window (as a const reference)
         const bEngineInputState &get_input_state() const;
@@ -110,6 +117,10 @@ namespace bEngine
         /// @brief gets the ID associated with this window
         /// @return the ID associated with this window
         const unsigned int get_window_ID() const;
+
+        /// @brief presents the results of the render commands which were issued to this window since the last time the
+        /// present method was called (i.e. swaps the buffers)
+        void present() const;
 
         /// @brief sets the window's 'should close' state
         /// @param shouldClose true means the window should close, false means it should not close

--- a/src/bEngineGL.cpp
+++ b/src/bEngineGL.cpp
@@ -5,6 +5,13 @@
 /// @file bEngineGL.cpp
 /// @brief implementations for the bEngineGL.h file
 
+#include "bEngineUtilities.h" // for access to info messages, etc.
+
+namespace
+{
+    const bool platform_load_gl_function_pointers(bEngine::bEngineGL &gl);
+}
+
 const bool bEngine::bEngineGL::is_valid() const
 {
     // assume the struct/context is valid to start:
@@ -17,8 +24,61 @@ const bool bEngine::bEngineGL::is_valid() const
     //
     // the function pointer is only non nullptr if the function pointer has been loaded correctly; checking all of the
     // function pointers allows us to ensure all function pointers have been loaded
-
-    // isValid = isValid && (/*function pointer goes here*/);
+    isValid = isValid && AttachShader;
+    isValid = isValid && BindBufferBase;
+    isValid = isValid && BindFramebuffer;
+    isValid = isValid && BindSampler;
+    isValid = isValid && BindTextureUnit;
+    isValid = isValid && BindVertexArray;
+    isValid = isValid && BlendFunc;
+    isValid = isValid && BlitNamedFramebuffer;
+    isValid = isValid && CheckNamedFramebufferStatus;
+    isValid = isValid && ClearNamedFramebufferfi;
+    isValid = isValid && ClearNamedFramebufferfv;
+    isValid = isValid && CompileShader;
+    isValid = isValid && CreateBuffers;
+    isValid = isValid && CreateFramebuffers;
+    isValid = isValid && CreateProgram;
+    isValid = isValid && CreateSamplers;
+    isValid = isValid && CreateShader;
+    isValid = isValid && CreateTextures;
+    isValid = isValid && CreateVertexArrays;
+    isValid = isValid && DeleteBuffers;
+    isValid = isValid && DeleteFramebuffers;
+    isValid = isValid && DeleteProgram;
+    isValid = isValid && DeleteSamplers;
+    isValid = isValid && DeleteShader;
+    isValid = isValid && DeleteTextures;
+    isValid = isValid && DeleteVertexArrays;
+    isValid = isValid && DetachShader;
+    isValid = isValid && Disable;
+    isValid = isValid && DrawArrays;
+    isValid = isValid && DrawArraysInstanced;
+    isValid = isValid && Enable;
+    isValid = isValid && GetProgramInfoLog;
+    isValid = isValid && GetProgramiv;
+    isValid = isValid && GetShaderInfoLog;
+    isValid = isValid && GetShaderiv;
+    isValid = isValid && GetTextureImage;
+    isValid = isValid && LinkProgram;
+    isValid = isValid && NamedBufferStorage;
+    isValid = isValid && NamedBufferSubData;
+    isValid = isValid && NamedFramebufferTexture;
+    isValid = isValid && PixelStorei;
+    isValid = isValid && ProgramUniform4fv;
+    isValid = isValid && ProgramUniformMatrix4fv;
+    isValid = isValid && SamplerParameterf;
+    isValid = isValid && SamplerParameterfv;
+    isValid = isValid && SamplerParameterIiv;
+    isValid = isValid && SamplerParameterIuiv;
+    isValid = isValid && SamplerParameteri;
+    isValid = isValid && SamplerParameteriv;
+    isValid = isValid && ShaderSource;
+    isValid = isValid && TextureParameteri;
+    isValid = isValid && TextureStorage2D;
+    isValid = isValid && TextureSubImage2D;
+    isValid = isValid && UseProgram;
+    isValid = isValid && Viewport;
 
     return isValid;
 }
@@ -28,8 +88,104 @@ const bool bEngine::load_gl_function_pointers(bEngineGL &gl)
     // reset the provided struct just in case it's been loaded into before:
     gl = {};
 
-    // to-do: implement gl function loading!
+    // delegate to the platform-specific function pointer loading method; if unsuccessful return false
+    const bool platformGLSuccess = platform_load_gl_function_pointers(gl);
+    if (!platformGLSuccess)
+    {
+        return false;
+    }
 
-    // return the validity of the loaded gl "context"
+    // return the validity of the loaded gl "context" which is only true if all of the desired gl function pointers were
+    // loaded
     return gl.is_valid();
 }
+
+#ifdef WIN32
+
+#    include <glad\gl.h> // for GL function pointer loading
+
+namespace
+{
+    const bool platform_load_gl_function_pointers(bEngine::bEngineGL &gl)
+    {
+        INFO_MSG("[PLATFORM] Loading GL function pointers with glad.");
+
+        // the glad gl context to load all function pointers into, from which we'll cherry pick the ones we actually
+        // want
+        GladGLContext gladGL{};
+
+        // load the glad gl function pointers
+        const auto gladSuccess = gladLoaderLoadGLContext(&gladGL);
+
+        // return false if there was an error loading the glad gl function pointers
+        if (!gladSuccess)
+        {
+            return false;
+        }
+
+        // now we just copy the desired function pointer values into our GL struct!
+        gl.AttachShader                = gladGL.AttachShader;
+        gl.BindBufferBase              = gladGL.BindBufferBase;
+        gl.BindFramebuffer             = gladGL.BindFramebuffer;
+        gl.BindSampler                 = gladGL.BindSampler;
+        gl.BindTextureUnit             = gladGL.BindTextureUnit;
+        gl.BindVertexArray             = gladGL.BindVertexArray;
+        gl.BlendFunc                   = gladGL.BlendFunc;
+        gl.BlitNamedFramebuffer        = gladGL.BlitNamedFramebuffer;
+        gl.CheckNamedFramebufferStatus = gladGL.CheckNamedFramebufferStatus;
+        gl.ClearNamedFramebufferfi     = gladGL.ClearNamedFramebufferfi;
+        gl.ClearNamedFramebufferfv     = gladGL.ClearNamedFramebufferfv;
+        gl.CompileShader               = gladGL.CompileShader;
+        gl.CreateBuffers               = gladGL.CreateBuffers;
+        gl.CreateFramebuffers          = gladGL.CreateFramebuffers;
+        gl.CreateProgram               = gladGL.CreateProgram;
+        gl.CreateSamplers              = gladGL.CreateSamplers;
+        gl.CreateShader                = gladGL.CreateShader;
+        gl.CreateTextures              = gladGL.CreateTextures;
+        gl.CreateVertexArrays          = gladGL.CreateVertexArrays;
+        gl.DeleteBuffers               = gladGL.DeleteBuffers;
+        gl.DeleteFramebuffers          = gladGL.DeleteFramebuffers;
+        gl.DeleteProgram               = gladGL.DeleteProgram;
+        gl.DeleteSamplers              = gladGL.DeleteSamplers;
+        gl.DeleteShader                = gladGL.DeleteShader;
+        gl.DeleteTextures              = gladGL.DeleteTextures;
+        gl.DeleteVertexArrays          = gladGL.DeleteVertexArrays;
+        gl.DetachShader                = gladGL.DetachShader;
+        gl.Disable                     = gladGL.Disable;
+        gl.DrawArrays                  = gladGL.DrawArrays;
+        gl.DrawArraysInstanced         = gladGL.DrawArraysInstanced;
+        gl.Enable                      = gladGL.Enable;
+        gl.GetProgramInfoLog           = gladGL.GetProgramInfoLog;
+        gl.GetProgramiv                = gladGL.GetProgramiv;
+        gl.GetShaderInfoLog            = gladGL.GetShaderInfoLog;
+        gl.GetShaderiv                 = gladGL.GetShaderiv;
+        gl.GetTextureImage             = gladGL.GetTextureImage;
+        gl.LinkProgram                 = gladGL.LinkProgram;
+        gl.NamedBufferStorage          = gladGL.NamedBufferStorage;
+        gl.NamedBufferSubData          = gladGL.NamedBufferSubData;
+        gl.NamedFramebufferTexture     = gladGL.NamedFramebufferTexture;
+        gl.PixelStorei                 = gladGL.PixelStorei;
+        gl.ProgramUniform4fv           = gladGL.ProgramUniform4fv;
+        gl.ProgramUniformMatrix4fv     = gladGL.ProgramUniformMatrix4fv;
+        gl.SamplerParameterf           = gladGL.SamplerParameterf;
+        gl.SamplerParameterfv          = gladGL.SamplerParameterfv;
+        gl.SamplerParameterIiv         = gladGL.SamplerParameterIiv;
+        gl.SamplerParameterIuiv        = gladGL.SamplerParameterIuiv;
+        gl.SamplerParameteri           = gladGL.SamplerParameteri;
+        gl.SamplerParameteriv          = gladGL.SamplerParameteriv;
+        gl.ShaderSource                = gladGL.ShaderSource;
+        gl.TextureParameteri           = gladGL.TextureParameteri;
+        gl.TextureStorage2D            = gladGL.TextureStorage2D;
+        gl.TextureSubImage2D           = gladGL.TextureSubImage2D;
+        gl.UseProgram                  = gladGL.UseProgram;
+        gl.Viewport                    = gladGL.Viewport;
+
+        // unload the glad gl context (not strictly needed)
+        gladLoaderUnloadGLContext(&gladGL);
+
+        // the platform-loading portion went correctly, so return true! It is up to another method to determine if the
+        // gl context which was passed to store the function pointers in is actually valid or not
+        return true;
+    };
+} // namespace
+#endif // WIN32

--- a/src/bEngineGL.cpp
+++ b/src/bEngineGL.cpp
@@ -1,0 +1,35 @@
+#include "bEnginePCH.h" // include first since we're utilizing the PCH
+
+#include "bEngineGL.h"
+
+/// @file bEngineGL.cpp
+/// @brief implementations for the bEngineGL.h file
+
+const bool bEngine::bEngineGL::is_valid() const
+{
+    // assume the struct/context is valid to start:
+    bool isValid{true};
+
+    // remove the comments from the following line (and put the correct function pointer in the parentheses) to actually
+    // check the validity of the context
+    //
+    // this follows short circuit logic, so if isValid is ever false it will return false eventually
+    //
+    // the function pointer is only non nullptr if the function pointer has been loaded correctly; checking all of the
+    // function pointers allows us to ensure all function pointers have been loaded
+
+    // isValid = isValid && (/*function pointer goes here*/);
+
+    return isValid;
+}
+
+const bool bEngine::load_gl_function_pointers(bEngineGL &gl)
+{
+    // reset the provided struct just in case it's been loaded into before:
+    gl = {};
+
+    // to-do: implement gl function loading!
+
+    // return the validity of the loaded gl "context"
+    return gl.is_valid();
+}

--- a/src/bEngineGL.h
+++ b/src/bEngineGL.h
@@ -8,7 +8,165 @@ namespace bEngine
     /// @brief a struct which contains function pointers for all of the OpenGL functions a bEngineApp uses
     struct bEngineGL
     {
-        // to=do: add the GL function pointers bEngine utilizes!
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glAttachShader.xhtml];
+        void (*AttachShader)(unsigned int program, unsigned int shader){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBindBufferBase.xhtml];
+        void (*BindBufferBase)(unsigned int target, unsigned int index, unsigned int buffer){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBindFramebuffer.xhtml];
+        void (*BindFramebuffer)(unsigned int target, unsigned int framebuffer){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBindSampler.xhtml];
+        void (*BindSampler)(unsigned int unit, unsigned int sampler){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBindTextureUnit.xhtml];
+        void (*BindTextureUnit)(unsigned int unit, unsigned int texture){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBindVertexArray.xhtml];
+        void (*BindVertexArray)(unsigned int array){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBlendFunc.xhtml];
+        void (*BlendFunc)(unsigned int sfactor, unsigned int dfactor){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBlitFramebuffer.xhtml];
+        void (*BlitNamedFramebuffer)(
+            unsigned int readFramebuffer,
+            unsigned int drawFramebuffer,
+            int          srcX0,
+            int          srcY0,
+            int          srcX1,
+            int          srcY1,
+            int          dstX0,
+            int          dstY0,
+            int          dstX1,
+            int          dstY1,
+            unsigned int mask,
+            unsigned int filter){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glCheckFramebufferStatus.xhtml];
+        unsigned int (*CheckNamedFramebufferStatus)(unsigned int framebuffer, unsigned int target){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml];
+        void (*ClearNamedFramebufferfi)(
+            unsigned int framebuffer,
+            unsigned int buffer,
+            int          drawbuffer,
+            float        depth,
+            int          stencil){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml];
+        void (*ClearNamedFramebufferfv)(
+            unsigned int framebuffer,
+            unsigned int buffer,
+            int          drawbuffer,
+            const float *value){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glCompileShader.xhtml];
+        void (*CompileShader)(unsigned int shader){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glCreateBuffers.xhtml];
+        void (*CreateBuffers)(int n, unsigned int *buffers){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glCreateFramebuffers.xhtml];
+        void (*CreateFramebuffers)(int n, unsigned int *framebuffers){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glCreateProgram.xhtml];
+        unsigned int (*CreateProgram)(){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glCreateSamplers.xhtml];
+        void (*CreateSamplers)(int n, unsigned int *samplers){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glCreateShader.xhtml];
+        unsigned int (*CreateShader)(unsigned int shaderType){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glCreateTextures.xhtml];
+        void (*CreateTextures)(unsigned int target, int n, unsigned int *textures){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glCreateVertexArrays.xhtml];
+        void (*CreateVertexArrays)(int n, unsigned int *arrays){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDeleteBuffers.xhtml];
+        void (*DeleteBuffers)(int count, const unsigned int *framebuffers){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDeleteFramebuffers.xhtml];
+        void (*DeleteFramebuffers)(int count, const unsigned int *framebuffers){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDeleteProgram.xhtml];
+        void (*DeleteProgram)(unsigned int program){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDeleteSamplers.xhtml];
+        void (*DeleteSamplers)(int count, const unsigned int *samplers){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDeleteShader.xhtml];
+        void (*DeleteShader)(unsigned int shader){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDeleteTextures.xhtml];
+        void (*DeleteTextures)(int count, const unsigned int *textures){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDeleteVertexArrays.xhtml];
+        void (*DeleteVertexArrays)(int count, const unsigned int *arrays){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDetachShader.xhtml];
+        void (*DetachShader)(unsigned int program, unsigned int shader){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glEnable.xhtml];
+        void (*Disable)(unsigned int cap){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDrawArrays.xhtml];
+        void (*DrawArrays)(unsigned int mode, int first, int count){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDrawArraysInstanced.xhtml];
+        void (*DrawArraysInstanced)(unsigned int mode, int first, int count, int instanceCount){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glEnable.xhtml];
+        void (*Enable)(unsigned int cap){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetProgramInfoLog.xhtml];
+        void (*GetProgramInfoLog)(unsigned int program, int maxLength, int *length, char *infoLog){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetProgram.xhtml];
+        void (*GetProgramiv)(unsigned int program, unsigned int pname, int *params){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetShaderInfoLog.xhtml];
+        void (*GetShaderInfoLog)(unsigned int shader, int maxLength, int *length, char *infoLog){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetShader.xhtml];
+        void (*GetShaderiv)(unsigned int shader, unsigned int pname, int *params){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetTexImage.xhtml];
+        void (*GetTextureImage)(
+            unsigned int texture,
+            int          level,
+            unsigned int format,
+            unsigned int type,
+            int          bufSize,
+            void        *pixels){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glLinkProgram.xhtml];
+        void (*LinkProgram)(unsigned int program){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBufferStorage.xhtml];
+        void (*NamedBufferStorage)(unsigned int buffer, signed long long size, const void *data, unsigned int flags){
+            nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBufferSubData.xhtml];
+        void (
+            *NamedBufferSubData)(unsigned int buffer, signed long long offset, signed long long size, const void *data){
+            nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml];
+        void (*NamedFramebufferTexture)(
+            unsigned int framebuffer,
+            unsigned int attachment,
+            unsigned int texture,
+            int          level){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glPixelStore.xhtml];
+        void (*PixelStorei)(unsigned int oname, int param){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml];
+        void (*ProgramUniform4fv)(unsigned int program, int location, int count, const float *value){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glProgramUniform.xhtml];
+        void (*ProgramUniformMatrix4fv)(
+            unsigned int  program,
+            int           location,
+            int           count,
+            unsigned char transpose,
+            const float  *value){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml];
+        void (*SamplerParameterf)(unsigned int sampler, unsigned int pname, float param){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml];
+        void (*SamplerParameterfv)(unsigned int sampler, unsigned int pname, const float *params){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml];
+        void (*SamplerParameterIiv)(unsigned int sampler, unsigned int pname, const int *params){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml];
+        void (*SamplerParameterIuiv)(unsigned int sampler, unsigned int pname, const unsigned int *params){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml];
+        void (*SamplerParameteri)(unsigned int sampler, unsigned int pname, int param){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glSamplerParameter.xhtml];
+        void (*SamplerParameteriv)(unsigned int sampler, unsigned int pname, const int *params){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glShaderSource.xhtml];
+        void (*ShaderSource)(unsigned int shader, int count, const char *const *string, const int *length){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexParameter.xhtml];
+        void (*TextureParameteri)(unsigned int texture, unsigned int pname, int param){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexStorage2D.xhtml];
+        void (*TextureStorage2D)(unsigned int texture, int levels, unsigned int internalformat, int width, int height){
+            nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexSubImage2D.xhtml];
+        void (*TextureSubImage2D)(
+            unsigned int texture,
+            int          level,
+            int          xoffset,
+            int          yoffset,
+            int          width,
+            int          height,
+            unsigned int format,
+            unsigned int type,
+            const void  *pixels){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glUseProgram.xhtml];
+        void (*UseProgram)(unsigned int program){nullptr};
+        /// @brief see [https://registry.khronos.org/OpenGL-Refpages/gl4/html/glViewport.xhtml];
+        void (*Viewport)(int x, int y, int width, int height){nullptr};
 
         /// @brief checks whether this bEngineGL struct has all of the function pointers loaded
         /// @return true only if all of the function pointers are non nullptr, false otherwise (i.e. function pointers

--- a/src/bEngineGL.h
+++ b/src/bEngineGL.h
@@ -1,0 +1,23 @@
+#pragma once
+
+/// @file bEngineGL.h
+/// @brief OpenGL related structs and function pointer loading method
+
+namespace bEngine
+{
+    /// @brief a struct which contains function pointers for all of the OpenGL functions a bEngineApp uses
+    struct bEngineGL
+    {
+        // to=do: add the GL function pointers bEngine utilizes!
+
+        /// @brief checks whether this bEngineGL struct has all of the function pointers loaded
+        /// @return true only if all of the function pointers are non nullptr, false otherwise (i.e. function pointers
+        /// failed to load)
+        const bool is_valid() const;
+    };
+
+    /// @brief loads the desired GL function pointers into the provided bEngineGL struct
+    /// @param gl the bEngineGL struct which is to house the loaded function pointers
+    /// @return true only if all function pointers were loaded successfully (i.e. the bEngineGL struct is "valid")
+    const bool load_gl_function_pointers(bEngineGL &gl);
+} // namespace bEngine

--- a/src/bEngineWindow.cpp
+++ b/src/bEngineWindow.cpp
@@ -5,6 +5,7 @@
 /// @file bEngineWindow.cpp
 /// @brief implementations for the bEngineWindow.h file
 
+#include "bEngineGL.h"        // for access to the GL struct/context which must be managed per window
 #include "bEngineUtilities.h" // for access to info messaging, etc.
 
 #include <format> // for formatting info messages, etc.
@@ -46,17 +47,37 @@ struct bEngine::bEngineWindow::PlatformWindowImpl
     /// @brief the GLFWWindow* associated with this PlatformWindowImpl
     GLFWwindow *const m_glfwWindow{nullptr};
 
+    /// @brief the gl context associated with the window
+    ///
+    /// there's no need to actually expose bare OpenGL functions to the user, so we'll store this in the PIMPL and
+    /// forward calls from the interface!
+    bEngineGL m_gl{};
+
     /// @brief default ctor is insufficient
     PlatformWindowImpl() = delete;
 
     /// @brief ctor which takes the necessary arguments to actually construct a PlatformWindowImpl
     ///
+    /// also loads the GL function pointers into this window's gl context
     /// creates a GLFWwindow and stores the pointer to the window
     /// @param width the desired width of the window (in pixels)
     /// @param height the desired height of the window (in pixels)
     /// @param title the desired title of the window
     PlatformWindowImpl(const int width, const int height, const char *const title)
-        : m_glfwWindow{create_glfw_window_with_hints(width, height, title)} { };
+        : m_glfwWindow{create_glfw_window_with_hints(width, height, title)}
+    {
+        // the glfw window must be the current context when loading the gl function pointers for the windows
+        // implementation...
+        glfwMakeContextCurrent(m_glfwWindow);
+
+        // load the gl function pointers
+        const bool glSuccess = load_gl_function_pointers(m_gl);
+
+        // ALL windows must successfully load a GL context; use an assertion to cause a crash if something is wrong
+        //
+        // this will throw an std::exception; without an associated try/catch block this will terminate the program
+        bENGINE_ASSERT(glSuccess, "Failed to load the GL context for the window.");
+    };
 
     /// @brief dtor destroys the GLFWwindow associated with this PlatformWindowImpl
     ~PlatformWindowImpl() { glfwDestroyWindow(m_glfwWindow); };

--- a/src/bEngineWindow.cpp
+++ b/src/bEngineWindow.cpp
@@ -8,6 +8,9 @@
 #include "bEngineGL.h"        // for access to the GL struct/context which must be managed per window
 #include "bEngineUtilities.h" // for access to info messaging, etc.
 
+#include <glm\glm.hpp>          // for access to vec4
+#include <glm\gtc\type_ptr.hpp> // for accessing vecs as float pointers, etc.
+
 #include <format> // for formatting info messages, etc.
 
 #pragma region PLATFORM_IMPLEMENTATIONS
@@ -89,7 +92,10 @@ struct bEngine::bEngineWindow::PlatformWindowImpl
     /// window should stay open
     const bool get_should_close() const { return glfwWindowShouldClose(m_glfwWindow); };
 
-    /// @brief sets  the window's "should close" state by calling the GLFW provided function
+    /// @brief swaps the buffers of the window, presenting the results of rendering functions
+    void present() const { glfwSwapBuffers(m_glfwWindow); };
+
+    /// @brief sets the window's "should close" state by calling the GLFW provided function
     /// @param shouldClose true if the window should close (i.e. we're programatically closing a window) and false if
     /// the window should stay open
     void set_should_close(const bool shouldClose) const
@@ -235,6 +241,13 @@ bEngine::bEngineWindow::bEngineWindow(WindowToken, const int width, const int he
 
 bEngine::bEngineWindow::~bEngineWindow() { };
 
+void bEngine::bEngineWindow::clear(const float r, const float g, const float b, const float a) const
+{
+    const auto &gl = m_impl->m_gl;
+
+    gl.ClearNamedFramebufferfv(0, GL_COLOR, 0, glm::value_ptr(glm::vec4{r, g, b, a}));
+}
+
 const bEngine::bEngineInputState &bEngine::bEngineWindow::get_input_state() const
 {
     return m_inputState;
@@ -261,6 +274,11 @@ const bool bEngine::bEngineWindow::get_should_close() const
 const unsigned int bEngine::bEngineWindow::get_window_ID() const
 {
     return m_windowID;
+}
+
+void bEngine::bEngineWindow::present() const
+{
+    m_impl->present();
 }
 
 void bEngine::bEngineWindow::set_should_close(const bool shouldClose) const


### PR DESCRIPTION
Closes #12 .

The bEngineGL struct is not meant to be directly exposed to the user; instead the GL function calls are wrapped by window methods.

The list of GL function pointers to load was taken from an old project-- not all of the functions are utilized at this time. The list can be pruned in the future if needed.

Added a window "clear" function which takes as arguments 4 floats corresponding to the RGBA channels of a color. After calling this method (or any window "rendering" method) the results must be presented to the window with the window's "present" method. This swaps the buffers of the window, effectively displaying the render results.

The example titled "rendering" shows how to clear the window with a red color and present the results to the screen.